### PR TITLE
Speed up testing with faster passwords

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,5 +48,6 @@ locust \
     --headless \
     --host http://127.0.0.1:8000 \
     --run-time 1m \
+    --spawn-rate 4 \
     --users 4
 ```

--- a/bakerydemo/base/fixtures/bakerydemo.json
+++ b/bakerydemo/base/fixtures/bakerydemo.json
@@ -1569,7 +1569,7 @@
     "model": "auth.user",
     "pk": 3,
     "fields": {
-      "password": "pbkdf2_sha256$30000$eIoVnauBvLhA$aPWJSlHK+F/rW7SKunxJ/RnXNQHx0uh6K/kVRyPn0XY=",
+      "password": "md5$5Ve4NkWG4cZGuZfP8OVjjc$32150a4e7e476653fc1252641890cc71",
       "last_login": "2019-04-23T19:58:19.460Z",
       "is_superuser": true,
       "username": "admin",

--- a/bakerydemo/settings/base.py
+++ b/bakerydemo/settings/base.py
@@ -122,19 +122,12 @@ DATABASES = {
 # Password validation
 # https://docs.djangoproject.com/en/3.2/ref/settings/#auth-password-validators
 
-AUTH_PASSWORD_VALIDATORS = [
-    {
-        "NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",
-    },
-    {
-        "NAME": "django.contrib.auth.password_validation.NumericPasswordValidator",
-    },
+# Intentionally set empty to speed up benchmarking
+AUTH_PASSWORD_VALIDATORS = []
+
+# Fastest possible login which isn't deprecated
+PASSWORD_HASHERS = [
+    "django.contrib.auth.hashers.MD5PasswordHasher",
 ]
 
 


### PR DESCRIPTION
Django's password hashers are intentionally designed to slow down logins - which slows down our testing. Switching this to one of the weaker (and still supported without deprecation warnings) password hashers.

Switching to this also seems to fix login issues when spawn rate was set to a higher number - so updating the README to prompt that as an option.