### PR TITLE
Faster testing

### DIFF
--- a/locustfile.py
+++ b/locustfile.py
@@ -9,7 +9,7 @@ class BaseWagtailUser(HttpUser):
 
     def on_start(self):
         # Login to the Wagtail admin so we can view the pages API
-        response = self.client.get("/admin/")
+        response = self.client.get("/admin/login/")
         form = _get_form(
             response,
             formname=None,
@@ -27,8 +27,9 @@ class BaseWagtailUser(HttpUser):
             clickdata=None,
         )
         self.client.post(
-            "/admin/login/?next=/admin/",
+            "/admin/login/",
             form_data,
+            allow_redirects=False,
         )
 
         # Store the list of pages for view_page
@@ -87,5 +88,6 @@ class WagtailEditor(BaseWagtailUser):
         response = self.client.post(
             admin_url,
             form_data,
+            allow_redirects=False,
             name="/admin/pages/[{}]/edit/".format(wagtail_page["meta"]["type"]),
         )

--- a/locustfile.py
+++ b/locustfile.py
@@ -1,10 +1,11 @@
 import random
+from urllib.parse import urlencode
 
-from locust import HttpUser, task
+from locust import FastHttpUser, task
 from scrapy.http.request.form import _get_form, _get_inputs
 
 
-class BaseWagtailUser(HttpUser):
+class BaseWagtailUser(FastHttpUser):
     abstract = True
 
     def on_start(self):
@@ -26,9 +27,13 @@ class BaseWagtailUser(HttpUser):
             dont_click=False,
             clickdata=None,
         )
+        form_data_payload = urlencode(form_data).encode()
         self.client.post(
             "/admin/login/",
-            form_data,
+            data=form_data_payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
             allow_redirects=False,
         )
 
@@ -85,9 +90,13 @@ class WagtailEditor(BaseWagtailUser):
             dont_click=False,
             clickdata=None,
         )
+        form_data_payload = urlencode(form_data).encode()
         response = self.client.post(
             admin_url,
-            form_data,
-            allow_redirects=False,
             name="/admin/pages/[{}]/edit/".format(wagtail_page["meta"]["type"]),
+            data=form_data_payload,
+            headers={
+                "Content-Type": "application/x-www-form-urlencoded",
+            },
+            allow_redirects=False,
         )


### PR DESCRIPTION
Couple of tweaks:

- Use `allow_redirects=False` to stop requests following a redirect (which means another GET request which usually isn't needed).
- Switch to [FastHttpUser](https://docs.locust.io/en/stable/increase-performance.html), which has a few quirks as it didn't accept a list of tuples for POST requests (which is easy to work around).